### PR TITLE
docs: remove invalid `-Force` parameter from ConvertFrom-SecureString examples

### DIFF
--- a/website/docs/connect-maester/connect-maester-advanced.md
+++ b/website/docs/connect-maester/connect-maester-advanced.md
@@ -145,11 +145,11 @@ If you already have an authenticated Azure context (e.g., managed identity, work
 #$moera = "contoso.onmicrosoft.com"
 
 # Exchange Online
-$outlookToken = ConvertFrom-SecureString -SecureString (Get-AzAccessToken -ResourceUrl 'https://outlook.office365.com' -AsSecureString).Token -AsPlainText -Force
+$outlookToken = ConvertFrom-SecureString -SecureString (Get-AzAccessToken -ResourceUrl 'https://outlook.office365.com' -AsSecureString).Token -AsPlainText
 Connect-ExchangeOnline -AccessToken $outlookToken -AppId $clientId -Organization $tenantId -ShowBanner:$false
 
 # Security & Compliance (IPPS)
-$isspToken = ConvertFrom-SecureString -SecureString (Get-AzAccessToken -ResourceUrl 'https://ps.compliance.protection.outlook.com' -AsSecureString).Token -AsPlainText -Force
+$isspToken = ConvertFrom-SecureString -SecureString (Get-AzAccessToken -ResourceUrl 'https://ps.compliance.protection.outlook.com' -AsSecureString).Token -AsPlainText
 Connect-IPPSSession -AccessToken $isspToken -Organization $moera
 ```
 
@@ -187,8 +187,8 @@ $graphToken = Get-AzAccessToken -ResourceUrl 'https://graph.microsoft.com' -AsSe
 $teamsToken = Get-AzAccessToken -ResourceUrl '48ac35b8-9aa8-4d74-927d-1f4a14a0b239' -AsSecureString
 
 $tokens = @(
-    (ConvertFrom-SecureString -SecureString $graphToken.Token -AsPlainText -Force),
-    (ConvertFrom-SecureString -SecureString $teamsToken.Token -AsPlainText -Force)
+    (ConvertFrom-SecureString -SecureString $graphToken.Token -AsPlainText),
+    (ConvertFrom-SecureString -SecureString $teamsToken.Token -AsPlainText)
 )
 
 Connect-MicrosoftTeams -AccessTokens $tokens


### PR DESCRIPTION
### Motivation
- Several examples recommended calling `ConvertFrom-SecureString` with a `-Force` switch even though that parameter does not exist, which could mislead users and break copy-paste usage.

### Description
- Removed the invalid `-Force` argument from `ConvertFrom-SecureString` examples in `website/docs/connect-maester/connect-maester-advanced.md` (Exchange Online, Security & Compliance, and Teams token examples). 
- Left generated/versioned documentation untouched per repository rules, and edited only the source documentation that is shipped from `website/docs`.
- Re-ran the website test-docs generation to ensure the source change does not introduce documentation inconsistencies.

### Testing
- Verified there are no remaining occurrences with `rg -n -U -i --glob '*.md' --glob '!website/versioned_docs/**' 'ConvertFrom-SecureString(?:.|\n){0,180}-Force|-Force(?:.|\n){0,180}ConvertFrom-SecureString'`, which returned no matches.
- Ran `npm run check-test-docs` (which invokes `node scripts/generate-test-docs.mjs --check`) and it completed successfully for all generated test pages.
- Ran `npm ci` and `npm run build` for the website where dependencies installed successfully and the build produced static files, with a note that the environment Node version differs from the project's declared engine (warning only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f2e0d1330832695cc85b6b18bd858)